### PR TITLE
Add printing support to adapt latest version of GTest.

### DIFF
--- a/src/core/fishstore.h
+++ b/src/core/fishstore.h
@@ -4010,5 +4010,9 @@ void FishStore<D, A>::PrintRegistration() {
   }
 }
 
+std::ostream& operator << (std::ostream& out, const Status s) {
+  return out << (uint8_t)s;
+}
+
 }
 } // namespace fishstore::core


### PR DESCRIPTION
In the latest version of gtest, it need all objects in assesrtions can be output through an output stream. `fishstore::core::Status` in the previous implementation does no have the required method. This PR is to fix such issue by adding printing support for it.